### PR TITLE
Use averaged confidence score rather than accumulated score

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo is from https://github.com/Parquery/lanms, which has provided a python
 
 In this repo, we fixed the bug so that anyone could compile the correct .whl for installation.
 
-Update 07-2021: use averaged confidence for merged bounding boxes, while in original paper the confidence score is an accumulated score. (Later one causes problem that more bbox or longer text results in higher confidence)
+**Update 07-2021** (@doem97) Use averaged confidence for merged bounding boxes, while in original paper the confidence score is an accumulated score. (Later one causes problem that more bbox or longer text would have higher confidence)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repo is from https://github.com/Parquery/lanms, which has provided a python
 
 In this repo, we fixed the bug so that anyone could compile the correct .whl for installation.
 
+Update 07-2021: use averaged confidence for merged bounding boxes, while in original paper the confidence score is an accumulated score. (Later one causes problem that more bbox or longer text results in higher confidence)
+
 ## Installation
 
 ```


### PR DESCRIPTION
In original LANMS, the confidence is the adding up of all merged boxes, which is unreasonable (confidence score can achieve up to 49 even 100).
This update uses the averaged score of all merged boxes, thus the score of each output bbox is still [0,1] and can represent the confidence of bbox.